### PR TITLE
第５章型によるドメインモデリングを 5.6 まで写経

### DIFF
--- a/F#/F#.sln
+++ b/F#/F#.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "chap04", "chap04\chap04.fsproj", "{F4631F75-C1CD-4434-9D35-88F83F5D8A34}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "chap05", "chap05\chap05.fsproj", "{91089774-7153-42E0-B721-F833200476BC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{F4631F75-C1CD-4434-9D35-88F83F5D8A34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4631F75-C1CD-4434-9D35-88F83F5D8A34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4631F75-C1CD-4434-9D35-88F83F5D8A34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91089774-7153-42E0-B721-F833200476BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91089774-7153-42E0-B721-F833200476BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91089774-7153-42E0-B721-F833200476BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91089774-7153-42E0-B721-F833200476BC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/F#/chap05/Chap0503.fs
+++ b/F#/chap05/Chap0503.fs
@@ -1,0 +1,16 @@
+namespace Chap0503
+
+module C050301 =
+    type CustomerId = CustomerId of int
+    type OrderId = OrderId of int
+    type WidgetCode = WidgetCode of string
+    type UnitQuantity = UnitQuantity of int
+    type KilogramQuantity = KilogramQuantity of decimal
+
+module C050303 =
+    type UnitQuantity = int
+
+module C050303a =
+    [<Struct>]
+    type UnitQuantity = UnitQuantity of int
+    type UnitQuantities = UnitQuantities of int[]

--- a/F#/chap05/Chap0504.fs
+++ b/F#/chap05/Chap0504.fs
@@ -1,0 +1,27 @@
+namespace Chap0504
+
+open Chap0503.C050301
+
+type Undefined = exn
+type CustomerInfo = Undefined
+type ShippingAddress = Undefined
+type BillingAddress = Undefined
+type OrderLine = Undefined
+type BillingAmount = Undefined
+
+type Order =
+    { CustomerInfo: CustomerInfo
+      ShippingAddress: ShippingAddress
+      BillingAddress: BillingAddress
+      OrderLines: OrderLine list
+      AmountToBill: BillingAmount }
+
+type GizmoCode = Undefined
+
+type ProductCode =
+    | Widget of WidgetCode
+    | Gizmo of GizmoCode
+
+type OrderQuantity =
+    | Unit of UnitQuantity
+    | Kilogram of KilogramQuantity

--- a/F#/chap05/Chap0505.fs
+++ b/F#/chap05/Chap0505.fs
@@ -1,0 +1,56 @@
+namespace Chap0505
+
+open Chap0504
+open Microsoft.FSharp.Core
+
+type UnvalidatedOrder = Undefined
+type ValidatedOrder = Undefined
+
+type AcknowledgmentSent = Undefined
+type OrderPlaced = Undefined
+type BillableOrderPlaced = Undefined
+
+type QuoteForm = Undefined
+type OrderForm = Undefined
+type ProductCatalog = Undefined
+type PricedOrder = Undefined
+type EnvelopeContents = EnvelopeContents of string
+
+type ValidationError =
+    { FieldName: string
+      ErrorDescription: string }
+
+module C050501 =
+    type ValidateOrder = UnvalidatedOrder -> ValidatedOrder
+
+    type PlaceOrderEvents =
+        { AcknowledgmentSent: AcknowledgmentSent
+          OrderPlaced: OrderPlaced
+          BillableOrderPlaced: BillableOrderPlaced }
+
+    type PlaceOrder = UnvalidatedOrder -> PlaceOrderEvents
+
+    type CategorizedMail =
+        | Quote of QuoteForm
+        | Order of OrderForm
+
+    type CategorizeInboundMail = EnvelopeContents -> CategorizedMail
+
+    type CalculatePrices = OrderForm -> ProductCatalog -> PricedOrder
+
+module C050501a =
+    type CalculatedPricesInput =
+        { OrderForm: OrderForm
+          ProductCatalog: ProductCatalog }
+
+    type CalculatePrices = CalculatedPricesInput -> PricedOrder
+
+module C050502 =
+    type ValidateOrder = UnvalidatedOrder -> Result<ValidatedOrder, ValidationError list>
+
+module C050502a =
+    type ValidateOrder = UnvalidatedOrder -> Async<Result<ValidatedOrder, ValidationError list>>
+
+module C050502b =
+    type ValidationResponse<'a> = Async<Result<'a, ValidationError list>>
+    type ValidateOrder = UnvalidatedOrder -> ValidationResponse<ValidatedOrder>

--- a/F#/chap05/Program.fs
+++ b/F#/chap05/Program.fs
@@ -1,0 +1,2 @@
+﻿// For more information see https://aka.ms/fsharp-console-apps
+printfn "Hello from F#"

--- a/F#/chap05/Program.fs
+++ b/F#/chap05/Program.fs
@@ -1,4 +1,5 @@
 ﻿open Chap0503.C050301
+open Program.Chap0406
 
 printfn "Chapter 5.3"
 
@@ -6,16 +7,38 @@ let customerId = CustomerId 42
 let orderId = OrderId 42
 
 // println $"%b{orderId = customerId}"
-printfn """
+printfn
+    """
 ./domain_modeling_made_functional/F#/chap05/Program.fs(15,25): error FS0001: この式に必要な型は    'OrderId'    ですが、ここでは次の型が指定されています    'CustomerId'
 """
 
 let processCustomerId (id: CustomerId) = printfn $"Customer ID is {id}"
 
 // processCustomerId orderId
-printfn """
+printfn
+    """
 ./domain_modeling_made_functional/F#/chap05/Program.fs(27,19): error FS0001: この式に必要な型は    'CustomerId'    ですが、ここでは次の型が指定されています    'OrderId'
 """
 
 let (CustomerId innerValue) = customerId
 printfn $"innerValue is {innerValue}"
+
+printfn ""
+printfn "Chapter 5.6"
+
+let widgetCode1 = WidgetCode "W1234"
+let widgetCode2 = WidgetCode "W1234"
+
+printfn $"widgetCode1 = widgetCode2 : {widgetCode1 = widgetCode2}"
+
+let name1 =
+    { FirstName = "Alex"
+      MiddleInitial = None
+      LastName = "Adams" }
+
+let name2 =
+    { FirstName = "Alex"
+      MiddleInitial = None
+      LastName = "Adams" }
+
+printfn $"name1 = name2 : {name1 = name2}"

--- a/F#/chap05/Program.fs
+++ b/F#/chap05/Program.fs
@@ -1,2 +1,21 @@
-﻿// For more information see https://aka.ms/fsharp-console-apps
-printfn "Hello from F#"
+﻿open Chap0503.C050301
+
+printfn "Chapter 5.3"
+
+let customerId = CustomerId 42
+let orderId = OrderId 42
+
+// println $"%b{orderId = customerId}"
+printfn """
+./domain_modeling_made_functional/F#/chap05/Program.fs(15,25): error FS0001: この式に必要な型は    'OrderId'    ですが、ここでは次の型が指定されています    'CustomerId'
+"""
+
+let processCustomerId (id: CustomerId) = printfn $"Customer ID is {id}"
+
+// processCustomerId orderId
+printfn """
+./domain_modeling_made_functional/F#/chap05/Program.fs(27,19): error FS0001: この式に必要な型は    'CustomerId'    ですが、ここでは次の型が指定されています    'OrderId'
+"""
+
+let (CustomerId innerValue) = customerId
+printfn $"innerValue is {innerValue}"

--- a/F#/chap05/chap05.fsproj
+++ b/F#/chap05/chap05.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/F#/chap05/chap05.fsproj
+++ b/F#/chap05/chap05.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Chap0503.fs" />
+    <Compile Include="Chap0504.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap05/chap05.fsproj
+++ b/F#/chap05/chap05.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Chap0503.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap05/chap05.fsproj
+++ b/F#/chap05/chap05.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="Chap0503.fs" />
     <Compile Include="Chap0504.fs" />
+    <Compile Include="Chap0505.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap05/chap05.fsproj
+++ b/F#/chap05/chap05.fsproj
@@ -4,8 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
-
+  
   <ItemGroup>
+    <ProjectReference Include="..\chap04\chap04.fsproj" />
     <Compile Include="Chap0503.fs" />
     <Compile Include="Chap0504.fs" />
     <Compile Include="Chap0505.fs" />


### PR DESCRIPTION
- F# のファイル分割方法、namespace, module の扱いがわかってきた気がする
- F# は別に型エイリアスの記法があるので、Scalaとの対応を完全に勘違いしていた
    - `type A = A of string` の書き方は基本的に `case class A (value: String)` と同等で良さそう

