### PR TITLE
5.3 単純な値のモデリングをScalaで写経

### DIFF
--- a/Scala/chap05/src/main/scala/Chap0503/C050301.scala
+++ b/Scala/chap05/src/main/scala/Chap0503/C050301.scala
@@ -1,0 +1,23 @@
+package Chap0503
+
+object C050301:
+  case class CustomerId(value: Int)
+
+  case class OrderId(value: Int)
+
+  case class WidgetCode(value: String)
+
+  case class UnitQuantity(value: Int)
+
+  case class KilogramQuantity(value: BigDecimal)
+
+  opaque type CustomerId2 = Int
+
+  object CustomerId2:
+    def apply(value: Int): CustomerId2 = value
+
+  opaque type OrderId2 = Int
+
+  object OrderId2:
+    def apply(value: Int): OrderId2 = value
+

--- a/Scala/chap05/src/main/scala/Chap0503/C050303.scala
+++ b/Scala/chap05/src/main/scala/Chap0503/C050303.scala
@@ -1,0 +1,4 @@
+package Chap0503
+
+object C050303:
+  type UnitQuantity = Int

--- a/Scala/chap05/src/main/scala/Chap0503/C050303a.scala
+++ b/Scala/chap05/src/main/scala/Chap0503/C050303a.scala
@@ -1,0 +1,5 @@
+package Chap0503
+
+object C050303a:
+  opaque type UnitQuantity = Int
+  opaque type UnitQuantities = Seq[Int]

--- a/Scala/chap05/src/main/scala/main.scala
+++ b/Scala/chap05/src/main/scala/main.scala
@@ -1,2 +1,43 @@
+import Chap0503.C050301.*
+
 @main def hello(): Unit =
-  println("Chapter 5")
+  println("Chapter 5.3")
+
+  val customerId = CustomerId(42)
+  val customerId2 = CustomerId2(42)
+  val orderId = OrderId(42)
+  val orderId2 = OrderId2(42)
+  // 比較は F# とかなり動きが違う
+  println(s"${customerId == orderId}")
+  println(s"${customerId eq orderId}")
+  println(s"${customerId2 == orderId2}")
+  //  println(s"${customerId2 eq orderId2}")
+  println(
+    """
+      |[error] -- [E008] Not Found Error: ./domain_modeling_made_functional/scala/chap05/src/main/scala/main.scala:13:26
+      |[error] 13 |  println(s"${customerId2 eq orderId2}")
+      |[error]    |              ^^^^^^^^^^^^^^
+      |[error]    |      value eq is not a member of Chap0503.C050301.CustomerId2.
+      |""".stripMargin)
+
+  def processCustomerId(id: CustomerId) = println(s"Customer ID is $id")
+  //  processCustomerId(orderId)
+  println(
+    """
+      |[error] -- [E007] Type Mismatch Error: ./domain_modeling_made_functional/scala/chap05/src/main/scala/main.scala:22:20
+      |[error] 22 |  processCustomerId(orderId)
+      |[error]    |                    ^^^^^^^
+      |[error]    |                    Found:    (orderId : Chap0503.C050301.OrderId)
+      |[error]    |                    Required: Chap0503.C050301.CustomerId
+      |[error]    |
+      |[error]    | longer explanation available when compiling with `-explain`
+      |[error] one error found
+      |""".stripMargin)
+
+  val CustomerId(innerValue) = customerId
+  // これは動かない
+  //  val CustomerId2(innerValue2) = customerId2
+  println(s"innerValue is $innerValue")
+
+  println
+  println("Chapter 5.6")


### PR DESCRIPTION
opaque type の方が良いかと思って色々書いてみたが、いちいち apply を実装しないといけないのがとてもめんどくさい
雑に書くなら、case class を使った方が楽な気がしないでもない

あと、Scalaは割と色々比較可能なので、そこがF#と違ったかな...