### PR TITLE
5.4 複雑なデータのモデリングをScalaで写経

### DIFF
--- a/Scala/chap05/src/main/scala/Chap0504/Domain.scala
+++ b/Scala/chap05/src/main/scala/Chap0504/Domain.scala
@@ -1,0 +1,19 @@
+package Chap0504
+
+case class CustomerInfo(value: Any)
+
+case class ShippingAddress(value: Any)
+
+case class BillingAddress(value: Any)
+
+case class OrderLine(value: Any)
+
+case class BillingAmount(value: Any)
+
+case class WidgetCode(value: Any)
+
+case class GizmoCode(value: Any)
+
+case class UnitQuantity(value: Any)
+
+case class KilogramQuantity(value: Any)

--- a/Scala/chap05/src/main/scala/Chap0504/Order.scala
+++ b/Scala/chap05/src/main/scala/Chap0504/Order.scala
@@ -1,0 +1,10 @@
+package Chap0504
+
+
+case class Order(
+                  customerInfo: CustomerInfo,
+                  shippingAddress: ShippingAddress,
+                  billingAddress: BillingAddress,
+                  orderLines: List[OrderLine],
+                  amountToBill: BillingAmount,
+                )

--- a/Scala/chap05/src/main/scala/Chap0504/OrderQuantity.scala
+++ b/Scala/chap05/src/main/scala/Chap0504/OrderQuantity.scala
@@ -1,0 +1,5 @@
+package Chap0504
+
+enum OrderQuantity:
+  case Unit(value: UnitQuantity)
+  case Kilogram(value: KilogramQuantity)

--- a/Scala/chap05/src/main/scala/Chap0504/ProductCode.scala
+++ b/Scala/chap05/src/main/scala/Chap0504/ProductCode.scala
@@ -1,0 +1,5 @@
+package Chap0504
+
+enum ProductCode:
+  case Widget(code: WidgetCode)
+  case Gizmo(code: GizmoCode)


### PR DESCRIPTION
opaque を使うのはやめて基本的に case class と enum で記述するようにした

それ以外は特に書くようなこともない