### PR TITLE
5.5　関数によるワークフローのモデリング  をScalaで写経

### DIFF
--- a/Scala/chap05/src/main/scala/Chap0505/C050501.scala
+++ b/Scala/chap05/src/main/scala/Chap0505/C050501.scala
@@ -1,0 +1,19 @@
+package Chap0505
+
+object C050501:
+  type ValidateOrder = UnvalidatedOrder => ValidatedOrder
+
+  case class PlaceOrderEvents(
+                               acknowledgmentSent: AcknowledgmentSent,
+                               orderPlaced: OrderPlaced,
+                               billableOrderPlaced: BillableOrderPlaced,
+                             )
+
+  type PlaceOrder = UnvalidatedOrder => PlaceOrderEvents
+
+  enum CategorizedMail:
+    case Quote(value: QuoteForm)
+    case Order(value: OrderForm)
+
+  type CategorizeInboundMail = EnvelopeContents => CategorizedMail
+  type CalculatePrices = OrderForm => ProductCatalog => PricedOrder

--- a/Scala/chap05/src/main/scala/Chap0505/C050501a.scala
+++ b/Scala/chap05/src/main/scala/Chap0505/C050501a.scala
@@ -1,0 +1,6 @@
+package Chap0505
+
+object C050501a:
+  case class CalculatedPricesInput(orderForm: OrderForm, productCatalog: ProductCatalog)
+
+  type CalculatePrices = CalculatedPricesInput => PricedOrder

--- a/Scala/chap05/src/main/scala/Chap0505/C050502.scala
+++ b/Scala/chap05/src/main/scala/Chap0505/C050502.scala
@@ -1,0 +1,5 @@
+package Chap0505
+
+object C050502:
+  // Left がエラーなのでResultとは位置が変わる。あと、型消去が問題になりそう
+  type ValidateOrder = UnvalidatedOrder => Either[Seq[ValidationError], ValidatedOrder]

--- a/Scala/chap05/src/main/scala/Chap0505/C050502a.scala
+++ b/Scala/chap05/src/main/scala/Chap0505/C050502a.scala
@@ -1,0 +1,7 @@
+package Chap0505
+
+import scala.concurrent.Future
+
+object C050502a:
+  // 非同期処理は Future を使う
+  type ValidateOrder = UnvalidatedOrder => Future[Either[Seq[ValidationError], ValidatedOrder]]

--- a/Scala/chap05/src/main/scala/Chap0505/C050502b.scala
+++ b/Scala/chap05/src/main/scala/Chap0505/C050502b.scala
@@ -1,0 +1,8 @@
+package Chap0505
+
+import scala.concurrent.Future
+
+object C050502b:
+  // 型パラメータはつい T を使ってしまう
+  type ValidationResponse[T] = UnvalidatedOrder => Future[Either[T, ValidatedOrder]]
+  type ValidateOrder = UnvalidatedOrder => ValidationResponse[Seq[ValidationError]]

--- a/Scala/chap05/src/main/scala/Chap0505/Domain.scala
+++ b/Scala/chap05/src/main/scala/Chap0505/Domain.scala
@@ -1,0 +1,24 @@
+package Chap0505
+
+
+case class UnvalidatedOrder(value: Any)
+
+case class ValidatedOrder(value: Any)
+
+case class AcknowledgmentSent(value: Any)
+
+case class OrderPlaced(value: Any)
+
+case class BillableOrderPlaced(value: Any)
+
+case class QuoteForm(value: Any)
+
+case class OrderForm(value: Any)
+
+case class ProductCatalog(value: Any)
+
+case class PricedOrder(value: Any)
+
+case class EnvelopeContents(value: String)
+
+case class ValidationError(fieldName: String, errorDescription: String)


### PR DESCRIPTION
基本的にはF#と若干構文が違うだけで、ほぼ再現できているような気がする

多分、以下の対応で合ってる
- `Result -> Either`
- `Async -> Future`

