### PR TITLE
5.9 すべてを組み合わせる をScalaで写経

### DIFF
--- a/F#/OrderTaking/Domain.fs
+++ b/F#/OrderTaking/Domain.fs
@@ -3,7 +3,7 @@ namespace OrderTaking.Domain
 // 製品コード関連
 /// TODO: 制約: 先頭が "W" + 数字4桁
 type WidgetCode = WidgetCode of string
-/// TODO: 制約: 先頭が "W" + 数字4桁
+/// TODO: 制約: 先頭が "G" + 数字3桁
 type GizmoCode = GizmoCode of string
 
 type ProductCode =

--- a/Scala/ordertaking/src/main/scala/Domain.scala
+++ b/Scala/ordertaking/src/main/scala/Domain.scala
@@ -1,0 +1,94 @@
+// TODO: コンストラクタを隠蔽したり、apply のすり抜けを気にしないといけない感じになってくるなら、opaque の方が良さそう
+
+// 製品コード関連
+/// TODO: 先頭が "W" + 数字4桁
+case class WidgetCode(value: String)
+
+/// TODO: 先頭が "G" + 数字3桁
+case class GizmoCode(value: String)
+
+enum ProductCode:
+  case Widget(code: WidgetCode)
+  case Gizmo(code: GizmoCode)
+
+// 注文数量関連
+case class UnitQuantity(value: Int)
+
+case class KilogramQuantity(value: BigDecimal)
+
+enum OrderQuantity:
+  case Unit(value: UnitQuantity)
+  case Kilos(value: KilogramQuantity)
+
+// 注文関連の識別子
+// TODO: Any は未確定
+case class OrderId(value: Any)
+
+case class OrderLineId(value: Any)
+
+case class CustomerId(value: Any)
+
+// 注文関連
+// TODO: Any は未確定
+case class CustomerInfo(value: Any)
+
+case class ShippingAddress(value: Any)
+
+case class BillingAddress(value: Any)
+
+case class Price(value: Any)
+
+case class BillingAmount(value: Any)
+
+// Order集約
+case class OrderLine(
+                      id: OrderLineId,
+                      orderId: OrderId,
+                      productCode: ProductCode,
+                      orderQuantity: OrderQuantity,
+                      price: Price,
+                    )
+
+case class Order(
+                  id: OrderId,
+                  customerInfo: CustomerInfo,
+                  shippingAddress: ShippingAddress,
+                  billingAddress: BillingAddress,
+                  orderLines: Seq[OrderLine],
+                  amountToBill: BillingAmount,
+                )
+
+// ワークフローの構成要素
+case class UnvalidatedOrderLine(
+                                 id: String,
+                                 orderId: String,
+                                 productCode: String,
+                                 orderQuantity: String,
+                               )
+
+case class UnvalidatedOrder(
+                             id: String,
+                             customerInfo: String,
+                             shippingAddress: String,
+                             billingAddress: String,
+                             orderLines: Seq[UnvalidatedOrderLine],
+                           )
+
+case class BillableOrderPlaced(
+                                orderId: OrderId,
+                                billingAddress: BillingAddress,
+                                amountToBill: BillingAmount,
+                              )
+
+case class PlaceOrderEvents(
+                             acknowledgementSent: Boolean,
+                             orderPlaced: Order,
+                             billableOrderPlaced: BillableOrderPlaced,
+                           )
+
+case class ValidationErrors(fieldName: String, errorDescription: String)
+
+case class PlaceOrderError(errors: Seq[ValidationErrors])
+
+// 注文確定プロセス
+type PlaceOrder = UnvalidatedOrder => Either[PlaceOrderError, PlaceOrderEvents]


### PR DESCRIPTION
- 基本的に、 case class + enum で記述
    - case class は多機能なので、困ったらあとで考える
        - opaque type を使うなど
- F# の `and` キーワードに対応するようなものはないので、内側のクラスから順番に記述
    - `and` があると Order -> OrderLine の順で記述できる
    - ないので、 OrderLine -> Order で記述している
- あとは F# 側でコメントの記述ミスがあったので修正