### PR TITLE
第６章ドメインの完全性と整合性を写経

### DIFF
--- a/F#/F#.sln
+++ b/F#/F#.sln
@@ -9,6 +9,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "chap05", "chap05\chap05.fsp
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "OrderTaking", "OrderTaking\OrderTaking.fsproj", "{C8191DD6-CE50-4747-A8BD-0CCA9A0ABC8F}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "chap06", "chap06\chap06.fsproj", "{34323682-F552-4782-9981-0EF6DEAF1FCC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{C8191DD6-CE50-4747-A8BD-0CCA9A0ABC8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8191DD6-CE50-4747-A8BD-0CCA9A0ABC8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8191DD6-CE50-4747-A8BD-0CCA9A0ABC8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34323682-F552-4782-9981-0EF6DEAF1FCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34323682-F552-4782-9981-0EF6DEAF1FCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34323682-F552-4782-9981-0EF6DEAF1FCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34323682-F552-4782-9981-0EF6DEAF1FCC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/F#/OrderTaking/Domain.fs
+++ b/F#/OrderTaking/Domain.fs
@@ -1,18 +1,16 @@
 namespace OrderTaking.Domain
 
 // 製品コード関連
-/// TODO: 制約: 先頭が "W" + 数字4桁
-type WidgetCode = WidgetCode of string
-/// TODO: 制約: 先頭が "G" + 数字3桁
-type GizmoCode = GizmoCode of string
+type WidgetCode = WidgetCode of string // TODO: 制約: 先頭が "W" + 数字4桁
+type GizmoCode = GizmoCode of string // TODO: 制約: 先頭が "G" + 数字3桁
 
 type ProductCode =
     | Widget of WidgetCode
     | Gizmo of GizmoCode
 
 // 注文数量関連
-type UnitQuantity = UnitQuantity of int
-type KilogramQuantity = KilogramQuantity of decimal
+type UnitQuantity = UnitQuantity of int // TODO: 1以上1000以下
+type KilogramQuantity = KilogramQuantity of decimal // TODO: 0.05以上100.00以下
 
 type OrderQuantity =
     | Unit of UnitQuantity

--- a/F#/chap06/Chap0601.fs
+++ b/F#/chap06/Chap0601.fs
@@ -1,0 +1,14 @@
+namespace Chap0601
+
+type UnitQuantity = private UnitQuantity of int
+
+module UnitQuantity =
+    let create qty =
+        if qty < 1 then
+            Error "UnitQuantity can not be negative"
+        else if qty > 1000 then
+            Error "UnitQuantity can not be more than 1000"
+        else
+            Ok(UnitQuantity qty)
+
+    let value (UnitQuantity qty) = qty

--- a/F#/chap06/Chap0602.fs
+++ b/F#/chap06/Chap0602.fs
@@ -1,0 +1,9 @@
+namespace Chap0602
+
+[<Measure>]
+type kg
+
+[<Measure>]
+type m
+
+type KilogramQuantity = KilogramQuantity of decimal<kg>

--- a/F#/chap06/Chap0603.fs
+++ b/F#/chap06/Chap0603.fs
@@ -1,0 +1,4 @@
+namespace Chap0603
+
+type NonEmptyList<'a> = { First: 'a; Rest: 'a list }
+

--- a/F#/chap06/Chap0604.fs
+++ b/F#/chap06/Chap0604.fs
@@ -48,3 +48,10 @@ module C0604f =
 
     type Contact =
         { Name: Name; ContactInfo: ContactInfo }
+
+module C060401 =
+    type UnvalidatedAddress = UnvalidatedAddress of string
+    type ValidatedAddress = private UnvalidatedAddress of string
+    type AddressValidationService = UnvalidatedAddress -> ValidatedAddress option
+    type UnvalidatedOrder = { ShippingAddress: UnvalidatedAddress }
+    type ValidatedOrder = { ShippingAddress: ValidatedAddress }

--- a/F#/chap06/Chap0604.fs
+++ b/F#/chap06/Chap0604.fs
@@ -1,0 +1,50 @@
+namespace Chap0604
+
+type EmailAddress = Undefiend
+
+type VerifiedEmailAddress = Undefiend
+
+module C0604a =
+    type CustomerEmail =
+        { EmailAddress: EmailAddress
+          IsVerified: bool }
+
+module C0604b =
+    type CustomerEmail =
+        | Unverified of EmailAddress
+        | Verified of EmailAddress
+
+module C0604c =
+    type CustomerEmail =
+        | Unverified of EmailAddress
+        | Verified of VerifiedEmailAddress
+
+type Name = Undefiend
+type EmailContactInfo = Undefiend
+type PostalContactInfo = Undefiend
+
+
+module C0604d =
+    type Contact =
+        { Name: Name
+          Email: EmailContactInfo
+          Address: PostalContactInfo }
+
+module C0604e =
+    type Contact =
+        { Name: Name
+          Email: EmailContactInfo option
+          Address: PostalContactInfo option }
+
+module C0604f =
+    type BothContactMethods =
+        { Email: EmailContactInfo
+          Address: PostalContactInfo }
+
+    type ContactInfo =
+        | EmailOnly of EmailContactInfo
+        | AddrOnly of PostalContactInfo
+        | EmailAndAddr of BothContactMethods
+
+    type Contact =
+        { Name: Name; ContactInfo: ContactInfo }

--- a/F#/chap06/Chap0605.fs
+++ b/F#/chap06/Chap0605.fs
@@ -1,0 +1,25 @@
+namespace Chap0605
+
+module C060501 =
+    type Order =
+        { OrderLines: OrderLine list
+          AmountToBill: float }
+
+    and OrderLine = { id: int; Price: float }
+
+    let findOrderLine orderLineId lines =
+        lines |> List.find (fun ol -> ol.id = orderLineId)
+
+    let replaceOrderLine orderLineId newOrderLine lines =
+        lines |> List.map (fun ol -> if ol.id = orderLineId then newOrderLine else ol)
+
+
+    let changeOrderLinePrice order orderLineId newPrice =
+        let orderLine = order.OrderLines |> findOrderLine orderLineId
+        let newOrderLine = { orderLine with Price = newPrice }
+        let newOrderLines = order.OrderLines |> replaceOrderLine orderLineId newOrderLine
+        let newAmountToBill = newOrderLines |> List.sumBy (fun line -> line.Price)
+
+        { order with
+            OrderLines = newOrderLines
+            AmountToBill = newAmountToBill }

--- a/F#/chap06/Program.fs
+++ b/F#/chap06/Program.fs
@@ -1,0 +1,20 @@
+﻿// For more information see https://aka.ms/fsharp-console-apps
+
+open Chap0601
+
+printfn "Chapter 6.1"
+
+// let unitQty = UnitQuantity 1
+printfn
+    """
+./domain_modeling_made_functional/F#/chap06/Program.fs(7,15): error FS1093: 型 'UnitQuantity' の共用体ケースまたはフィールドは、このコードの場所からアクセスできません
+"""
+
+let unitQtyResult = UnitQuantity.create 1
+
+match unitQtyResult with
+| Error msg -> printfn $"Failure. Message is {msg}"
+| Ok uQty ->
+    printfn $"Success. Value is {uQty}"
+    let innerValue = UnitQuantity.value uQty
+    printfn $"inner Value is {innerValue}"

--- a/F#/chap06/Program.fs
+++ b/F#/chap06/Program.fs
@@ -1,6 +1,7 @@
 ﻿// For more information see https://aka.ms/fsharp-console-apps
 
 open Chap0601
+open Chap0602
 
 printfn "Chapter 6.1"
 
@@ -18,3 +19,16 @@ match unitQtyResult with
     printfn $"Success. Value is {uQty}"
     let innerValue = UnitQuantity.value uQty
     printfn $"inner Value is {innerValue}"
+
+printfn "\nChapter 6.2"
+
+let fiveKilos = 5.0<kg>
+let fiveMeters = 5.0<m>
+
+// let res = fiveKilos = fiveMeters
+printfn """
+./domain_modeling_made_functional/F#/chap06/Program.fs(28,13): error FS0001: 型が一致しません。    'float<kg>'    という指定が必要ですが、    'float<m>'    が指定されました。測定単位 'm' と一致しません
+"""
+
+// コンパイルエラーにならないな...
+let listOfWeights = [fiveKilos, fiveMeters]

--- a/F#/chap06/chap06.fsproj
+++ b/F#/chap06/chap06.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Chap0601.fs" />
     <Compile Include="Chap0602.fs" />
     <Compile Include="Chap0603.fs" />
+    <Compile Include="Chap0604.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap06/chap06.fsproj
+++ b/F#/chap06/chap06.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Chap0601.fs" />
+    <Compile Include="Chap0602.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap06/chap06.fsproj
+++ b/F#/chap06/chap06.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="Chap0602.fs" />
     <Compile Include="Chap0603.fs" />
     <Compile Include="Chap0604.fs" />
+    <Compile Include="Chap0605.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap06/chap06.fsproj
+++ b/F#/chap06/chap06.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="Chap0601.fs" />
     <Compile Include="Chap0602.fs" />
+    <Compile Include="Chap0603.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/F#/chap06/chap06.fsproj
+++ b/F#/chap06/chap06.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Chap0601.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
```F#
let listOfWeights = [fiveKilos, fiveMeters]
```
この部分がエラーにならなかった。どうもリストではなく、タプルとして認識されている様子

NonEmptyListとか出てきたので、Scala側は Cats を入れてみた方がいいのかなぁ