### PR TITLE
第６章をScalaで写経

### DIFF
--- a/Scala/chap06/src/main/scala/Chap0604.scala
+++ b/Scala/chap06/src/main/scala/Chap0604.scala
@@ -1,0 +1,71 @@
+import Chap0604.*
+
+object Chap0604:
+  case class EmailAddress(value: String)
+
+  case class VerifiedEmailAddress(value: String)
+
+  case class Name(value: String)
+
+  case class EmailContactInfo(value: String)
+
+  case class PostalContactInfo(value: String)
+
+object C0604a:
+  case class CustomerEmail(
+                            email: EmailAddress,
+                            isVerified: Boolean,
+                          )
+
+object C0604b:
+  enum CustomerEmail:
+    case Unverified(email: EmailAddress)
+    case Verified(email: EmailAddress)
+
+
+object C0604c:
+  enum CustomerEmail:
+    case Unverified(email: EmailAddress)
+    case Verified(email: VerifiedEmailAddress)
+
+
+object C0606d:
+  case class Contact(
+                      name: Name,
+                      email: EmailContactInfo,
+                      address: PostalContactInfo,
+                    )
+
+object C0606e:
+  case class Contact(
+                      name: Name,
+                      email: Option[EmailContactInfo],
+                      address: Option[PostalContactInfo],
+                    )
+
+object C0606f:
+  case class BothContactMethods(
+                                 email: EmailContactInfo,
+                                 address: PostalContactInfo,
+                               )
+
+  enum ContactInfo:
+    case Email(email: EmailContactInfo)
+    case Address(address: PostalContactInfo)
+    case EmailAndAddr(email: EmailContactInfo, address: PostalContactInfo)
+
+  case class Contact(
+                      name: Name,
+                      info: ContactInfo,
+                    )
+
+object C060401:
+  case class UnvalidatedAddress(value: String)
+
+  case class ValidatedAddress(value: String)
+
+  type AddressValidationService = UnvalidatedAddress => Option[ValidatedAddress]
+
+  case class UnvalidatedOrder(shippingAddress: UnvalidatedAddress)
+
+  case class ValidatedOrder(shippingAddress: ValidatedAddress)

--- a/Scala/chap06/src/main/scala/Chap0605.scala
+++ b/Scala/chap06/src/main/scala/Chap0605.scala
@@ -1,0 +1,24 @@
+import scala.util.chaining.scalaUtilChainingOps
+
+object Chap0605:
+  case class OrderLine(id: Int, price: Float)
+
+  case class Order(lines: Seq[OrderLine], amountToBill: Float)
+
+  private def findOrderLine(orderLineId: Int, lines: Seq[OrderLine]): Either[String, OrderLine] =
+    lines.find(_.id == orderLineId) match
+      case Some(line) => Right(line)
+      case None => Left(s"OrderLine with id $orderLineId not found")
+
+  private def replaceOrderLine(orderLineId: Int, newLine: OrderLine, lines: Seq[OrderLine]): Seq[OrderLine] =
+    lines.map { line => if line.id == orderLineId then newLine else line }
+
+  def changeOrderLinePrice(order: Order, orderLineId: Int, newPrice: Float): Either[String, Order] =
+    for {
+      // Either lane
+      orderLine <- findOrderLine(orderLineId, order.lines)
+    } yield {
+      orderLine.copy(price = newPrice)
+        .pipe(replaceOrderLine(orderLineId, _, order.lines))
+        .pipe(lines => Order(lines, lines.map(_.price).sum))
+    }


### PR DESCRIPTION
書いてて気づいたが、以下のF#のコード部分には副作用が存在する


https://github.com/K-Bokka/domain_modeling_made_functional/blob/ac73ccc94f1692e76bcce50a0223e5049d8e0796/F%23/chap06/Chap0605.fs#L10-L11

https://learn.microsoft.com/ja-jp/dotnet/fsharp/language-reference/lists#search-operations-on-lists

Scalaにはこれに該当するメソッドはないので、とりあえずEither型を返すようにした
最終的な関数も、Either型を返すために for 内包表記にしている
