### PR TITLE
7.5 ~ 7.7 をScalaで写経

### DIFF
--- a/Scala/chap07/src/main/scala/Chap0705.scala
+++ b/Scala/chap07/src/main/scala/Chap0705.scala
@@ -1,0 +1,60 @@
+import scala.concurrent.Future
+
+object Chap070501:
+  case class UnvalidatedAddress(Value: Any)
+
+  case class CheckedAddress(Value: Any)
+
+  case class AddressValidationError(Value: Any)
+
+  type FutureEither[A, B] = Future[Either[A, B]]
+  type CheckAddressExists = UnvalidatedAddress => FutureEither[AddressValidationError, CheckedAddress]
+
+  case class CheckProductCodeExists(Value: Any)
+
+  case class UnvalidatedOrder(Value: Any)
+
+  case class ValidatedOrder(Value: Any)
+
+  case class ValidationError(Value: Any)
+
+  type ValidateOrder =
+    CheckProductCodeExists // 依存
+      => CheckAddressExists // 依存
+      => UnvalidatedOrder // In
+      => FutureEither[ValidationError, ValidatedOrder] // Out
+
+object Chap070502:
+
+  import Chap070501.ValidatedOrder
+
+  case class PricingError(Value: String)
+
+  case class GetProductPrice(Value: Any)
+
+  case class PricedOrder(Value: Any)
+
+  type PriceOrder =
+    GetProductPrice // 依存
+      => ValidatedOrder // In
+      => Either[PricingError, PricedOrder] // Out
+
+object Chap070503:
+
+  import Chap070502.PricedOrder
+
+  case class OrderAcknowledgement(Value: Any)
+
+  case class SendResult(Value: Any)
+
+  type SendOrderAcknowledgment = OrderAcknowledgement => Future[SendResult]
+
+  case class CreateOrderAcknowledgmentLetter(Value: Any)
+
+  case class OrderAcknowledgmentSent(Value: Any)
+
+  type AcknowledgeOrder =
+    CreateOrderAcknowledgmentLetter // 依存
+      => SendOrderAcknowledgment // 依存
+      => PricedOrder // In
+      => Future[Option[OrderAcknowledgmentSent]] // Out

--- a/Scala/chap07/src/main/scala/Chap0706.scala
+++ b/Scala/chap07/src/main/scala/Chap0706.scala
@@ -1,0 +1,34 @@
+import cats.data.EitherT
+
+import scala.concurrent.Future
+
+object Chap0706:
+  case class UnvalidatedOrder(value: Any)
+
+  case class ValidatedOrder(value: Any)
+
+  case class ValidationError(value: Any)
+
+  case class PricedOrder(value: Any)
+
+  case class OrderAcknowledgmentSent(value: Any)
+
+  case class PricingError(value: Any)
+
+  case class PlaceOrderEvent(value: Any)
+
+  type ValidateOrder =
+    UnvalidatedOrder // In
+      => EitherT[Future, ValidationError, ValidatedOrder] // Out
+
+  type PriceOrder =
+    ValidatedOrder // In
+      => Either[PricingError, PricedOrder] // Out
+
+  type AcknowledgeOrder =
+    PricedOrder // In
+      => Future[Option[OrderAcknowledgmentSent]] // Out
+
+  type CreateEvents =
+    PricedOrder // In
+      => List[PlaceOrderEvent] // Out

--- a/Scala/chap07/src/main/scala/Chap0707.scala
+++ b/Scala/chap07/src/main/scala/Chap0707.scala
@@ -1,0 +1,54 @@
+import cats.data.EitherT
+
+import scala.concurrent.Future
+
+object Chap0707:
+
+  case class CheckProductCodeExists(value: Any)
+
+  case class CheckAddressExists(value: Any)
+
+  case class UnvalidatedOrder(value: Any)
+
+  case class ValidatedOrder(value: Any)
+
+  case class ValidationError(value: Any)
+
+  case class GetProductPrice(value: Any)
+
+  case class PricedOrder(value: Any)
+
+  case class PricingError(value: Any)
+
+  object PatternA:
+    type ValidateOrder =
+      CheckProductCodeExists // 依存
+        => CheckAddressExists // 依存
+        => UnvalidatedOrder // In
+        => EitherT[Future, ValidationError, ValidatedOrder] // Out
+
+    type PriceOrder =
+      GetProductPrice // 依存
+        => ValidatedOrder // In
+        => Either[PricingError, PricedOrder] // Out
+
+  object PatternB:
+    type ValidateOrder =
+      UnvalidatedOrder // In
+        => EitherT[Future, ValidationError, ValidatedOrder] // Out
+
+    type PriceOrder =
+      ValidatedOrder // In
+        => Either[PricingError, PricedOrder] // Out
+
+  case class PlaceOrder(value: Any)
+
+  case class PlaceOrderEvent(value: Any)
+
+  case class PlaceOrderError(value: Any)
+
+  type PlaceOrderWorkflow =
+    PlaceOrder // In
+      => EitherT[Future, PlaceOrderError, List[PlaceOrderEvent]]
+
+end Chap0707


### PR DESCRIPTION
- commit message をAIに書かせていたが、逆にわかりにくい気がしたので、簡潔な言葉で書くようにした
- AsyncResult を毎回定義するのが面倒になってきたので、EitherT で代用
- end を置いておいた方が、コピペした時のインデントが崩れないので書くようにした